### PR TITLE
Day 12 Grid Cleanup

### DIFF
--- a/src/util/grid.rs
+++ b/src/util/grid.rs
@@ -1,5 +1,5 @@
 use crate::util::point::Point;
-use std::ops::Index;
+use std::ops::{Index, IndexMut};
 
 pub struct Grid<T> {
     pub col_count: usize,
@@ -27,6 +27,11 @@ impl<T> Index<Point> for Grid<T> {
     type Output = T;
 
     fn index(&self, point: Point) -> &Self::Output {
-        return &self.contents[self.col_count * point.x + point.y];
+        return &self.contents[self.col_count * point.y + point.x];
+    }
+}
+impl<T> IndexMut<Point> for Grid<T> {
+    fn index_mut(&mut self, point: Point) -> &mut Self::Output {
+        return &mut self.contents[self.col_count * point.y + point.x];
     }
 }

--- a/src/year2024/day12.rs
+++ b/src/year2024/day12.rs
@@ -25,7 +25,7 @@ fn check_plot(
     (row, col): (usize, usize),
 ) -> (u32, u32, u32) {
     // If the neighboring plot is a different plot, count this as a perimeter.
-    if garden[Point::new(row, col)] != expected_plot {
+    if garden[Point::new(col, row)] != expected_plot {
         return (1, 0, 0);
     }
 
@@ -128,7 +128,7 @@ fn part1(garden: Grid<char>) -> (u32, u32) {
             let (perimeter, area, sides) = check_plot(
                 &garden,
                 &mut visited_squares,
-                garden[Point::new(row, col)],
+                garden[Point::new(col, row)],
                 (row, col),
             );
 


### PR DESCRIPTION
- Fixes the ordering of row / col in `Point`s used by `Grid`.
- Adds `IndexMut` to `Grid` so that grids can be modified.