### PR TITLE
Year 2024 Day 17 Advent

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ I am using Advent of Code as a way to learn Rust. I attempt to use best practice
 | 14  | [Restroom Redoubt](https://adventofcode.com/2024/day/14) | [Source](src/year2024/day14.rs) |
 | 15  | [Warehouse Woes](https://adventofcode.com/2024/day/15) | [Source](src/year2024/day15.rs) |
 | 16  | [Reindeer Maze](https://adventofcode.com/2024/day/16) | [Source](src/year2024/day16.rs) |
+| 17  | [Chronospatial Computer](https://adventofcode.com/2024/day/17) | [Source](src/year2024/day17.rs) |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,4 +21,5 @@ pub mod year2024 {
     pub mod day14;
     pub mod day15;
     pub mod day16;
+    pub mod day17;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,5 +24,6 @@ fn main() {
     // run_test!(year2024, day13);
     // run_test!(year2024, day14);
     // run_test!(year2024, day15);
-    run_test!(year2024, day16);
+    // run_test!(year2024, day16);
+    run_test!(year2024, day17);
 }

--- a/src/year2024/day17.rs
+++ b/src/year2024/day17.rs
@@ -129,26 +129,48 @@ fn part1(input: Input) -> String {
 fn part2(mut program: Vec<u64>) -> u64 {
     println!("{:?}", program);
 
-    let program_rev = program.clone().into_iter().rev();
+    let program_rev: Vec<u64> = program.clone().into_iter().rev().collect();
     println!("{:?}", program_rev);
 
     program.pop();
     program.pop();
 
-    return program_rev.fold(0, |acc, number| {
-        let mut i = 0;
-        return loop {
-            let result: Vec<u64> = process_program((((acc << 3) + i), 0, 0, program.clone()));
+    let mut stack = vec![];
 
-            println!("{} = {} - {} - {}", result[0], number, acc, i);
+    let mut i = 0;
+    let mut stack_index = 0;
 
-            if result[0] == number {
-                println!("{}", ((acc << 3) + i));
-                break ((acc << 3) + i);
-            }
+    while stack_index < program_rev.len() {
+        if i > 7 {
+            stack_index -= 1;
+            stack[stack_index] += 1;
+            i = stack[stack_index];
+            stack.pop();
+            continue;
+        }
+        let number = program_rev[stack_index];
 
-            i += 1;
-        };
+        let acc = stack.iter().fold(0, |acc, value| {
+            return (acc << 3) + value;
+        });
+
+        let result: Vec<u64> = process_program((((acc << 3) + i), 0, 0, program.clone()));
+
+        println!("{} = {} - {:#b} - {:#b}", result[0], number, acc, i);
+
+        if result[0] == number {
+            println!("#{} -> {:#b}", number, ((acc << 3) + i));
+            stack.push(i);
+            i = 0;
+            stack_index += 1;
+            continue;
+        }
+
+        i += 1;
+    }
+
+    return stack.iter().fold(0, |acc, value| {
+        return (acc << 3) + value;
     });
 }
 

--- a/src/year2024/day17.rs
+++ b/src/year2024/day17.rs
@@ -67,11 +67,6 @@ fn process_program((mut register_a, mut register_b, mut register_c, program): In
             &register_c,
         );
 
-        println!(
-            "A: {:#b}, B: {}, C: {} - Instruction: {}, operand: {}",
-            register_a, register_b, register_c, instruction, operand,
-        );
-
         match instruction {
             0 => {
                 // adv A / 2^(combo)
@@ -127,10 +122,7 @@ fn part1(input: Input) -> String {
 }
 
 fn part2(mut program: Vec<u64>) -> u64 {
-    println!("{:?}", program);
-
     let program_rev: Vec<u64> = program.clone().into_iter().rev().collect();
-    println!("{:?}", program_rev);
 
     program.pop();
     program.pop();
@@ -156,10 +148,7 @@ fn part2(mut program: Vec<u64>) -> u64 {
 
         let result: Vec<u64> = process_program((((acc << 3) + i), 0, 0, program.clone()));
 
-        println!("{} = {} - {:#b} - {:#b}", result[0], number, acc, i);
-
         if result[0] == number {
-            println!("#{} -> {:#b}", number, ((acc << 3) + i));
             stack.push(i);
             i = 0;
             stack_index += 1;
@@ -178,21 +167,9 @@ pub fn run() {
     let inputs = process_file("input/year2024/day17-part2.txt");
     let cloned_input = inputs.clone();
 
-    println!("{:?}", inputs);
-
     println!("Part 1: {:?}", part1(inputs));
 
-    let part_2_result = part2(cloned_input.3.clone());
+    let part_2_register_a = part2(cloned_input.3.clone());
 
-    println!(
-        "Part 2: {:?} - {:?}",
-        // "Part 2: {:?} ",
-        part_2_result,
-        part1((
-            part_2_result,
-            cloned_input.1,
-            cloned_input.2,
-            cloned_input.3
-        ))
-    );
+    println!("Part 2: {}", part_2_register_a);
 }

--- a/src/year2024/day17.rs
+++ b/src/year2024/day17.rs
@@ -108,10 +108,32 @@ fn part1((mut register_a, mut register_b, mut register_c, program): Input) -> St
         .join(",");
 }
 
+fn part2(program: Vec<u32>) -> u32 {
+    return program
+        .into_iter()
+        .rev()
+        .reduce(|acc, number| ((number + acc) * (2 * 2 * 2)))
+        .expect("There must be a final value.");
+}
+
 pub fn run() {
     let inputs = process_file("input/year2024/day17.txt");
+    let cloned_input = inputs.clone();
 
     println!("{:?}", inputs);
 
     println!("Part 1: {:?}", part1(inputs));
+
+    let part_2_result = part2(cloned_input.3.clone());
+
+    println!(
+        "Part 2: {:?} - {:?}",
+        part_2_result,
+        part1((
+            part_2_result,
+            cloned_input.1,
+            cloned_input.2,
+            cloned_input.3
+        ))
+    );
 }

--- a/src/year2024/day17.rs
+++ b/src/year2024/day17.rs
@@ -1,8 +1,9 @@
 use crate::util::file::read;
 
-type Input = (u64, u64, u64, Vec<u64>);
+type Registers = (u64, u64, u64);
+type Program = Vec<u64>;
 
-fn process_file(filename: &str) -> Input {
+fn process_file(filename: &str) -> (Registers, Program) {
     let mut input_iter = read(filename).unwrap().flatten();
 
     fn parse_register(input_number: &str) -> u64 {
@@ -28,7 +29,7 @@ fn process_file(filename: &str) -> Input {
         })
         .collect::<Vec<u64>>();
 
-    return (a, b, c, program);
+    return ((a, b, c), program);
 }
 
 fn combo_operand(
@@ -52,7 +53,9 @@ fn combo_operand(
     };
 }
 
-fn process_program((mut register_a, mut register_b, mut register_c, program): Input) -> Vec<u64> {
+fn process_program(
+    ((mut register_a, mut register_b, mut register_c), program): (Registers, &Program),
+) -> Vec<u64> {
     let mut instruction_pointer: usize = 0;
     let mut output: Vec<u64> = vec![];
 
@@ -113,7 +116,7 @@ fn process_program((mut register_a, mut register_b, mut register_c, program): In
     return output;
 }
 
-fn part1(input: Input) -> String {
+fn part1(input: (Registers, &Program)) -> String {
     return process_program(input)
         .iter()
         .map(|x| x.to_string())
@@ -121,7 +124,7 @@ fn part1(input: Input) -> String {
         .join(",");
 }
 
-fn part2(mut program: Vec<u64>) -> u64 {
+fn part2(mut program: Program) -> u64 {
     let program_rev: Vec<u64> = program.clone().into_iter().rev().collect();
 
     program.pop();
@@ -133,6 +136,7 @@ fn part2(mut program: Vec<u64>) -> u64 {
     let mut stack_index = 0;
 
     while stack_index < program_rev.len() {
+        // If we've tried all options for the 3-bit number, undo the previous check to see if there are other valid options.
         if i > 7 {
             stack_index -= 1;
             stack[stack_index] += 1;
@@ -146,7 +150,7 @@ fn part2(mut program: Vec<u64>) -> u64 {
             return (acc << 3) + value;
         });
 
-        let result: Vec<u64> = process_program((((acc << 3) + i), 0, 0, program.clone()));
+        let result: Vec<u64> = process_program(((((acc << 3) + i), 0, 0), &program));
 
         if result[0] == number {
             stack.push(i);
@@ -165,11 +169,10 @@ fn part2(mut program: Vec<u64>) -> u64 {
 
 pub fn run() {
     let inputs = process_file("input/year2024/day17-part2.txt");
-    let cloned_input = inputs.clone();
 
-    println!("Part 1: {:?}", part1(inputs));
+    println!("Part 1: {:?}", part1((inputs.0, &inputs.1)));
 
-    let part_2_register_a = part2(cloned_input.3.clone());
+    let part_2_register_a = part2(inputs.1);
 
     println!("Part 2: {}", part_2_register_a);
 }

--- a/src/year2024/day17.rs
+++ b/src/year2024/day17.rs
@@ -1,0 +1,117 @@
+use crate::util::file::read;
+
+type Input = (u32, u32, u32, Vec<u32>);
+
+fn process_file(filename: &str) -> Input {
+    let mut input_iter = read(filename).unwrap().flatten();
+
+    fn parse_register(input_number: &str) -> u32 {
+        input_number.split(": ").collect::<Vec<&str>>()[1]
+            .parse::<u32>()
+            .expect("Input must have parsable number values.")
+    }
+
+    let a = parse_register(&input_iter.next().expect("Register A must have a value"));
+    let b = parse_register(&input_iter.next().expect("Register B must have a value"));
+    let c = parse_register(&input_iter.next().expect("Register C must have a value"));
+    // Skip the empty line in the input
+    input_iter.next();
+    let program = input_iter
+        .next()
+        .expect("Program line must exist")
+        .split(": ")
+        .collect::<Vec<&str>>()[1]
+        .split(',')
+        .map(|c| {
+            c.parse::<u32>()
+                .expect("Input must have parsable number values.")
+        })
+        .collect::<Vec<u32>>();
+
+    return (a, b, c, program);
+}
+
+const EXP_BASE: u32 = 2;
+
+fn part1((mut register_a, mut register_b, mut register_c, program): Input) -> String {
+    let mut instruction_pointer: usize = 0;
+    let mut output: Vec<u32> = vec![];
+
+    while let Some(instruction) = program.get(instruction_pointer) {
+        let next_operand = program[instruction_pointer + 1];
+
+        let operand = if instruction == &1 || instruction == &3 {
+            next_operand
+        } else {
+            match next_operand {
+                operand if operand <= 3 => operand as u32,
+                4 => register_a,
+                5 => register_b,
+                6 => register_c,
+                7 => panic!("Combo operand 7 is reserved and should not appear in valid programs"),
+                _ => panic!("Combo operand is outside the 3-bit range"),
+            }
+        };
+
+        println!(
+            "A: {}, B: {}, C: {} - Instruction: {}, operand: {}",
+            register_a, register_b, register_c, instruction, operand,
+        );
+
+        match instruction {
+            0 => {
+                // adv A / 2^(combo)
+                register_a = register_a / (EXP_BASE.pow(operand));
+            }
+            1 => {
+                //bxl - Bitwise XOR of register B and the literal operand
+                register_b = register_b ^ operand;
+            }
+            2 => {
+                //bst - Calculates the combo operand modulo 8. This stores only the lowest 3 bits.
+                register_b = operand % 8;
+            }
+            3 => {
+                // jnz - Jump to operand if Register A is not empty.
+                if register_a != 0 {
+                    instruction_pointer = operand as usize;
+                    // Continue to prevent regular increment on the instruction pointer
+                    continue;
+                }
+            }
+            4 => {
+                // bxc - B XOR C
+                register_b = register_b ^ register_c;
+            }
+            5 => {
+                // out - combo operand module 8
+                output.push(operand % 8);
+            }
+            6 => {
+                // bdv - works like adv but with B register
+                register_b = register_a / (EXP_BASE.pow(operand));
+            }
+            7 => {
+                // cdv - works like adv but with C register
+                register_c = register_a / (EXP_BASE.pow(operand));
+            }
+            _ => panic!("Instruction found larger than 3-bit maximum"),
+        };
+
+        instruction_pointer += 2;
+    }
+
+    return output
+        .iter()
+        .map(|x| x.to_string())
+        .collect::<Vec<String>>()
+        .join(",");
+}
+
+pub fn run() {
+    let inputs = process_file("input/year2024/day17.txt");
+
+    println!("{:?}", inputs);
+
+    println!("Part 1: {:?}", part1(inputs));
+}


### PR DESCRIPTION
### Year 2024 Day 17 Advent

Today's challenge requires implementing an assembly-like language containing 8 instructions. Instructions and operands are represented in 3-bit sets. Really cool to implement some of these bitwise operations and debug them!

The first part was fairly straightforward, requiring implementation of the 8 instructions and determining it's output. One shorthand I took was using the [arithmetic right hand shift](https://en.wikipedia.org/wiki/Arithmetic_shift) `>>` operator rather then dividing a value by `2^N`. This solves a problem where Rust's [u64 `pow` function](https://doc.rust-lang.org/std/primitive.u64.html#method.pow) takes a `u32` exponent, but our exponent numbers don't always fit in u32.

For the second part, we need to determine a value for Register A such that the program will output it's own program value. I identified that the program was loading 3 bits at a time from Register A, so my naive approach was to shift all program numbers into Register A. This passed for a simple example, but didn't work for a more complex program. At this point, I wrote each instruction in a readable format. I identified that the operations occurring in the program have to be factored into the provided Register A value, so the calculated Register A value had to check the operations happening.

I solved the problem by building a loop that checks the different possible combinations until it finds a possible value. Since the computer is 3-bit, there's only 8 possible values for each value in the program, so it's pretty quick to do this. If a number doesn't find a match, it means that it was dependent on a previous value that isn't correct. In these cases, the previous value is checked again to see if there were any other feasible values since there could be multiple valid options. Once all numbers are found, they are shifted together and returned as the determined Register A value.